### PR TITLE
Exclude mocks subpackage from linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bitrise*
 steps-check
+.idea

--- a/main.go
+++ b/main.go
@@ -30,7 +30,11 @@ workflows:
             set -ex
             pwd
             stepman audit --step-yml ./step.yml
-    - go-list: {}
+    - go-list:
+        inputs:
+        - exclude: |-
+            */vendor/*
+            */mocks
     - golint: {}
     - errcheck: {}
 


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _NO_ [version update](https://semver.org/)

### Context

Running `errcheck` on mocks generated by `mockery` fails because of unchecked type assertions. We don't want to lint autogenerated mocks anyway, so this PR excludes `mocks` subpackages from the list of packages to lint.

### Changes

Exclude `mocks` subpackages from the list of packages to lint.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
