### PR TITLE
Add YAML lint to workflow

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -2,6 +2,8 @@ extends: default
 
 ignore: |
   vendor/
+  .github/
+  _tmp/
 
 rules:
   line-length: disable

--- a/main.go
+++ b/main.go
@@ -30,9 +30,8 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -ex
-            echo $YAMLLINT_CONFIG_FILE
             pip3 install yamllint
-            yamllint --format colored .
+            yamllint --format colored . # Config file is implicitly set via $YAMLLINT_CONFIG_FILE
     - script@1:
         inputs:
         - content: |-


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Add YAML linting to our step CI workflows. Our tool of choice is [yamllint](https://yamllint.readthedocs.io/)

### Changes

- Add an extra step to the check workflow that runs `yamllint`
- The configuration file is a regular file in this repository, but it's embedded into the Go binary
- At runtime it's written to the temp folder and `$YAMLLINT_CONFIG_FILE` is set to its path. This env var is an implicit way to tell yamllint about the config file to use. This sounds a bit complicated, but this way we can store the lint config in a single place (this repo) and apply it to every step repo where we run this check step.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
