### PR TITLE
Replace golint and errcheck with golangci-lint

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,11 +30,6 @@ workflows:
             set -ex
             pwd
             stepman audit --step-yml ./step.yml
-    - go-list:
-        inputs:
-        - exclude: |-
-            */vendor/*
-            */mocks
     - script@1:
         title: Run golangci-lint
         inputs:


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
This step is not versioned yet.

### Context
* golint is deprecated and there's no 1:1 replacement.
* We are planning to use `golangci-lint` instead.

### Changes
**Run `golangci-lint` instead of `golint` and `errcheck`.**
* Removed unnecessary `go-list` step.