### PR TITLE
Add rule for enforcing a maximum of 1 empty newline in yaml files

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,6 +7,7 @@ ignore: |
   _tmp/
 
 rules:
+  empty-lines: {max: 1}
   line-length: disable
   document-start: disable
   indentation:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,7 +7,7 @@ ignore: |
   _tmp/
 
 rules:
-  empty-lines: {max: 1}
+  empty-lines: { max: 1 }
   line-length: disable
   document-start: disable
   indentation:


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

@godrei recommended I keep empty newlines in yaml files to just 1 line in [one of my recent PRs](https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/pull/1/files#r899038074). I don't have a strong opinion either way, but if that's a standard we want to stick to, we should add it to your default yamllint config.

### Changes

- Adds yamllint config option to enforce a maximum of one empty newline in yaml files.