### PR TITLE
Add .git to yamllint ignore config

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,10 +1,11 @@
 extends: default
 
 ignore: |
-  .bitrise.secrets.yml
-  vendor/
-  .github/
   _tmp/
+  .bitrise.secrets.yml
+  .git/
+  .github/
+  vendor/
 
 rules:
   empty-lines: { max: 1 }


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

~~Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)~~

Looks like we don't tag this Step, so no version change.

### Context

A recent pull request of mine started failing this check step, due to a tab character being found in a yaml file within the `.git` directory:

```
./.git/logs/refs/heads/update-urls-in-step.yml
  1:134     error    syntax error: found character '\t' that cannot start any token (syntax)

./.git/logs/refs/remotes/origin/update-urls-in-step.yml
  1:134     error    syntax error: found character '\t' that cannot start any token (syntax)
```

(Here's the failing CI build for reference: https://app.bitrise.io/build/4950b0dd-5c26-40a0-8799-365a34fe6768)

I don't know why this would suddenly start happening, but any file inside the `.git` directory is going to be generated for us, not written by us, so it should be ignored by linters.

### Changes

- Alphabetizes yamllint ignore list.
- Adds `.git/` to the yamllint ignore list.

### Investigation details

I've tested this change to the yamllint config locally, and it does fix my problem.