### PR TITLE
Update golangci-lint installation to use version 1.47.1

### DIFF
--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -45,7 +45,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -xeo pipefail
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.2
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.1
             golangci-lint run --timeout 5m
 
   unit_test:


### PR DESCRIPTION
### Version

Looks like we don't version this Step, so no version change needed.

### Context

There is a bug in the version of golangci-lint currently in use by this Step, causing it to fail when run using Go 1.18. The newest version works on Go 1.18, so we should update it.

### Changes

- Updates to install and use `v1.47.1` of golangci-lint
