### PR TITLE
Fix ignore for step.yml

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,11 +1,14 @@
 extends: default
 
+# Bitrise CLI contains _examples, _lessons
 ignore: |
   _tmp/
   .bitrise.secrets.yml
   .git/
   .github/
   vendor/
+  _examples/
+  _lessons/
 
 rules:
   empty-lines: { max: 1 }

--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -27,6 +27,7 @@ workflows:
             stepman audit --step-yml ./step.yml
     - git::https://github.com/bitrise-steplib/steps-validate-json-schema.git@main:
         title: Validate JSON schema
+        run_if: "{{enveq \"SKIP_STEP_YML_VALIDATION\" \"false\"}}"
         inputs:
         - schema_url: https://raw.githubusercontent.com/bitrise-io/bitrise-json-schemas/main/step.schema.json
         - yaml_path: ./step.yml

--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -46,7 +46,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -xeo pipefail
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.1
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.3
             golangci-lint run --timeout 5m
 
   unit_test:


### PR DESCRIPTION
### Context

Ignore step.yml schema validation if ignore flag is set. This allows use of check step with non-Step repositories, like Bitrise CLI.

### Changes
- Updated golangci-lint version
- Extended yaml ignore list with Bitrise CLI dirs

