### PR TITLE
Workaround for golangci-lint issue

### DIFF
--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -46,6 +46,7 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -xeo pipefail
+            export GOROOT=$(go env GOROOT)
             curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.3
             golangci-lint run --timeout 5m
 


### PR DESCRIPTION
#### Context

Error message: `panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt`.

Proposed workaround: https://github.com/golangci/golangci-lint/issues/2673#issuecomment-1205916993

Example build with error: https://app.bitrise.io/build/26e99736-ef6d-403b-be4d-47e7c255495f?tab=log.
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

