### PR TITLE
Remove preinstalled yamllint on linux

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 11
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
@@ -6,21 +6,8 @@ workflows:
     steps:
     - git::https://github.com/bitrise-steplib/steps-check.git: { }
 
-  ci:
-    envs:
-    - ORIG_WORKING_DIR: $BITRISE_SOURCE_DIR
+  e2e:
     steps:
-    - change-workdir:
-        title: Switch working dir to test / _tmp dir
-        description: |-
-          To prevent step testing issues, like referencing relative
-          files with just './some-file' in the step's code, which would
-          work for testing the step from this directory directly
-          but would break if the step is included in another `bitrise.yml`.
+    - git::https://github.com/bitrise-steplib/steps-check.git:
         inputs:
-        - path: ./_tmp
-        - is_create_path: true
-    - path::./:
-        title: Run current Step
-        inputs:
-        - step_dir: $ORIG_WORKING_DIR
+        - workflow: e2e

--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -13,6 +13,10 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -ex
+            # Remove old yamllint apt package
+            if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+                sudo apt-get remove yamllint -y
+            fi
             pip3 install yamllint
             yamllint --format colored . # Config file is implicitly set via $YAMLLINT_CONFIG_FILE
     - script@1:

--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -13,10 +13,6 @@ workflows:
         - content: |-
             #!/bin/env bash
             set -ex
-            # Remove old yamllint apt package
-            if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-                sudo apt-get remove yamllint -y
-            fi
             pip3 install yamllint
             yamllint --format colored . # Config file is implicitly set via $YAMLLINT_CONFIG_FILE
     - script@1:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,0 +1,22 @@
+format_version: "11"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+workflows:
+  test_smoke_self_test:
+    envs:
+    - ORIG_WORKING_DIR: $BITRISE_SOURCE_DIR
+    steps:
+    - change-workdir:
+        title: Switch working dir to test / _tmp dir
+        description: |-
+          To prevent step testing issues, like referencing relative
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - path::./:
+        title: Run current Step
+        inputs:
+        - step_dir: $ORIG_WORKING_DIR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Context

yamllint is now being preinstalled on linux, but it is a too old version (from 2019), that does not support passing the yamllint config through the environment variable `YAMLLINT_CONFIG_FILE`.

```+ pip3 install yamllint
Requirement already satisfied: yamllint in /usr/lib/python3/dist-packages (1.20.0)
+ yamllint --format colored .
./.golangci.yml
  1:1       warning  missing document start "---"  (document-start)
  3:3       error    wrong indentation: expected 4 but found 2  (indentation)
  ```

https://app.bitrise.io/build/9d54238c-eb62-4d72-b65c-7a4460dea21e

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
