### PR TITLE
Update golangci-lint

### DIFF
--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -52,7 +52,7 @@ workflows:
             #!/bin/env bash
             set -xeo pipefail
             export GOROOT=$(go env GOROOT)
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.3
+            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
             golangci-lint run --timeout 5m --color always
 
   unit_test:


### PR DESCRIPTION
Update golangci-lint to make it compatible with Go 1.20. The linux stack got updated to 1.20 and running the current version gives this error:

```
+ golangci-lint run --timeout 5m --color always
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
```