### PR TITLE
Add support for bash steps

### DIFF
--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -46,6 +46,7 @@ workflows:
             I\[#/inputs/\d+/opts/value_options\] S\[#/definitions/EnvVarOpts/properties/value_options/minItems\] minimum 2 items allowed, but found \d+ items
     - script@1:
         title: Run golangci-lint
+        run_if: "{{enveq \"SKIP_GO_CHECKS\" \"false\"}}"
         is_always_run: true
         inputs:
         - content: |-

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type Config struct {
 	WorkDir               string   `env:"step_dir,dir"`
 	Workflow              []string `env:"workflow,multiline"`
 	SkipStepYMLValidation bool     `env:"skip_step_yml_validation,opt[yes,no]"`
+	SkipGoChecks          bool     `env:"skip_go_checks,opt[yes,no]"`
 	SegmentWriteKey       string   `env:"SEGMENT_WRITE_KEY"`
 	ParentBuildURL        string   `env:"PARENT_BUILD_URL"`
 	IsCI                  bool     `env:"CI"`
@@ -108,7 +109,10 @@ func mainR() error {
 					Dir: config.WorkDir,
 					Env: []string{
 						fmt.Sprintf("STEP_DIR=%s", config.WorkDir),
-						fmt.Sprintf("SKIP_STEP_YML_VALIDATION=%t", config.SkipStepYMLValidation)},
+						fmt.Sprintf("SKIP_STEP_YML_VALIDATION=%t", config.SkipStepYMLValidation),
+						fmt.Sprintf("SKIP_GO_CHECKS=%t", config.SkipGoChecks),
+					},
+
 					Stdout: os.Stdout,
 					Stderr: os.Stderr,
 				})

--- a/step.yml
+++ b/step.yml
@@ -33,3 +33,9 @@ inputs:
     value_options:
     - "yes"
     - "no"
+- skip_go_checks: "no"
+  opts:
+    title: Skip golang related checks
+    value_options:
+    - "yes"
+    - "no"


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR adds support for non-golang steps, by introducing a new input: `skip_go_checks`.
If this input is set the `lint` workflow won't execute the `Run golangci-lint` step.

Usage example: https://github.com/bitrise-steplib/steps-script/pull/31
