### PR TITLE
Don't source `.zshrc` into a bash script

### DIFF
--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -32,6 +32,7 @@ workflows:
             else
                 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install pipx
                 pipx ensurepath
+                source ~/.bashrc # reload $PATH changes
             fi
 
             pipx install yamllint

--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -32,7 +32,6 @@ workflows:
             else
                 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install pipx
                 pipx ensurepath
-                source ~/.zshrc # reload $PATH changes
             fi
 
             pipx install yamllint

--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -31,6 +31,7 @@ workflows:
                 source ~/.bashrc # reload $PATH changes
             else
                 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install pipx
+                export PATH="$PATH:$HOME/.local/bin"
                 pipx ensurepath
                 source ~/.bashrc # reload $PATH changes
             fi


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

#39 

### Changes

I was dumb. This broke the moment a stack update added Zsh-specific shell completions to `.zshrc`. 

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
