### PR TITLE
Point config file URLs to master after branch merge

### DIFF
--- a/golang.bitrise.yml
+++ b/golang.bitrise.yml
@@ -18,8 +18,7 @@ step_bundles:
     - bundle::download-file:
         title: Download golangci-lint config file
         inputs:
-        # TODO: final URL
-        - url: https://raw.githubusercontent.com/bitrise-steplib/steps-check/refs/heads/bitrise-includes/.golangci.yml
+        - url: https://raw.githubusercontent.com/bitrise-steplib/steps-check/refs/heads/master/.golangci.yml
         - output_env_var: GOLANGCI_LINT_CONFIG_FILE
     - script@1:
         title: Run golangci-lint

--- a/yamlfmt.bitrise.yml
+++ b/yamlfmt.bitrise.yml
@@ -10,8 +10,7 @@ step_bundles:
     - bundle::download-file:
         title: Download ymlfmt config
         inputs:
-        # TODO: final URL
-        - url: https://raw.githubusercontent.com/bitrise-steplib/steps-check/refs/heads/bitrise-includes/.ymlfmt
+        - url: https://raw.githubusercontent.com/bitrise-steplib/steps-check/refs/heads/master/.ymlfmt
         - output_env_var: YAMLFMT_CONFIG_FILE
     - script@1:
         title: yamlfmt


### PR DESCRIPTION
## Summary

- Update golangci-lint and yamlfmt config file download URLs from the `bitrise-includes` branch ref to `master` now that #50 has been merged
- Remove the `# TODO: final URL` comments

## Test plan

- [ ] Verify the raw URLs resolve correctly on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)