### PR TITLE
Remove autofix-ci from legacy check workflow

### DIFF
--- a/checks.bitrise.yml
+++ b/checks.bitrise.yml
@@ -93,10 +93,6 @@ workflows:
               echo -e "\033[0;31mFailed to generate README.md.\033[0m"
               exit 1
             fi
-    - autofix-ci@1:
-        inputs:
-        - git_remote_url: $BITRISEIO_BASE_REPOSITORY_URL # default URL detection doesn't work because of Unified CI
-        - git_token: $PIPELINE_GITHUB_ACCESS_TOKEN # defined as a secret in Unified CI project
     - git::https://github.com/bitrise-steplib/steps-validate-json-schema.git@main:
         title: Validate JSON schema
         run_if: "{{enveq \"SKIP_STEP_YML_VALIDATION\" \"false\"}}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Follow-up to #52.

We learned the hard way that this `steps-check` and its now-legacy check workflow is included even in non-step repos. The same username + token secret pair is not available in those repos and their CI project, breaking their CI.

### Changes

Remove `autofix-ci` from the legacy check workflow. It's still included in the modern one, so there's one more incentive to migrate step repos to the new one.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
